### PR TITLE
Using pkgconfig for glfw linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Quick Start
 
-```console
+```bash
 $ ./build.sh
-$ ./main
+$ ./smoothlife_gpu
 ```
 
 ## References

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@
 set -xe
 
 clang -O3 -Wall -Wextra -o smoothlife_term smoothlife_term.c -lm
-clang -O3 -Wall -Wextra `pkg-config --cflags raylib` -o smoothlife_gpu smoothlife_gpu.c -lm `pkg-config --libs raylib` -ldl -lglfw -lpthread
+clang -O3 -Wall -Wextra `pkg-config --cflags raylib` -o smoothlife_gpu smoothlife_gpu.c -lm `pkg-config --libs raylib` `pkg-config --libs glfw3` -ldl -lpthread


### PR DESCRIPTION
I was having trouble with finding the lib path to glfw on my machine so I've just slightly modified the build command for `smoothlife_gpu` to find `glfw` via `pkg-config`.